### PR TITLE
Use File.cp! rather than File.rename!

### DIFF
--- a/lib/mix/tasks/esbuild.install.ex
+++ b/lib/mix/tasks/esbuild.install.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.Esbuild.Install do
     end
 
     bin_path = Esbuild.bin_path()
-    File.rename!(Path.join([tmp_dir, "package", "bin", "esbuild"]), bin_path)
+    File.cp!(Path.join([tmp_dir, "package", "bin", "esbuild"]), bin_path)
     Mix.shell().info("Installed esbuild #{version}")
   end
 


### PR DESCRIPTION
For users with `/tmp` mounted on another filesystem, `File.rename!` will
fail with `EXDEV: cross-device link not permitted`.
