### PR TITLE
Always re-enable the esbuild task

### DIFF
--- a/lib/mix/tasks/esbuild.ex
+++ b/lib/mix/tasks/esbuild.ex
@@ -33,6 +33,8 @@ defmodule Mix.Tasks.Esbuild do
       0 -> :ok
       status -> Mix.raise("`mix esbuild #{Enum.join(all, " ")}` exited with #{status}")
     end
+
+    Mix.Task.reenable("esbuild")
   end
 
   def run([]) do


### PR DESCRIPTION
It's typical to run esbuild several times with different options, for example if your build step produces both bundle.js and bundle.min.js

