### PR TITLE
Require Elixir 1.10, bump ci cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,7 @@ jobs:
 
       - uses: actions/cache@v2
         with:
-          path: |
-            deps
-            _build
+          path: deps
           key: ${{ runner.os }}-mix-${{matrix.pair.elixir}}-${{matrix.pair.otp}}-${{ hashFiles('**/mix.lock') }}-v1
 
       - run: mix deps.get

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: '1.9'
-              otp: 20
+              elixir: '1.10'
+              otp: 21
           - pair:
               elixir: '1.12'
               otp: 24
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: erlef/setup-beam@v1.7
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,9 +33,7 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-${{matrix.pair.elixir}}-${{matrix.pair.otp}}-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-
+          key: ${{ runner.os }}-mix-${{matrix.pair.elixir}}-${{matrix.pair.otp}}-${{ hashFiles('**/mix.lock') }}-v1
 
       - run: mix deps.get
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@v1.7
         with:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Esbuild.MixProject do
     [
       app: :esbuild,
       version: @version,
-      elixir: "~> 1.9",
+      elixir: "~> 1.10",
       deps: deps(),
       description: "Mix tasks for installing and invoking esbuild",
       package: [


### PR DESCRIPTION
We require Elixir 1.10 because it requires OTP 21+ which we need for the `:public_key.pkix_verify_hostname_match_fun` function to securely download.

Also updating the cache key. When we need to bump again, simply change to v2, etc.