### PR TITLE
Change bin_path to first try compile-time path and fallback to runtime

### DIFF
--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -81,7 +81,7 @@ defmodule Esbuild do
       """
   end
 
-  @bin_path Path.join(Path.dirname(Mix.Project.build_path()), "esbuild")
+  @build_path Mix.Project.build_path()
 
   @doc """
   Returns the path to the executable.
@@ -89,7 +89,16 @@ defmodule Esbuild do
   The executable may not be available if it was not yet installed.
   """
   def bin_path do
-    @bin_path
+    # First try compile-time path for Mix.install and releases, where the user may not have Mix.
+    # If that path doesn't exist it means the user relocated the release so we fallback to Mix.
+    build_path =
+      if File.exists?(@build_path) do
+        @build_path
+      else
+        Mix.Project.build_path()
+      end
+
+    Path.join(Path.dirname(build_path), "esbuild")
   end
 
   @doc """

--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -81,13 +81,15 @@ defmodule Esbuild do
       """
   end
 
+  @bin_path Path.join(Path.dirname(Mix.Project.build_path()), "esbuild")
+
   @doc """
   Returns the path to the executable.
 
   The executable may not be available if it was not yet installed.
   """
   def bin_path do
-    Path.join(Path.dirname(Mix.Project.build_path()), "esbuild")
+    @bin_path
   end
 
   @doc """


### PR DESCRIPTION
This is useful for Mix.install/2 because the build directory is only effectively accessible at the compile time.

With this patch we can do this:

    $ elixir -e 'Application.put_env(:esbuild, :version, "0.12.17"); Mix.install([{:esbuild, path: "~/src/esbuild"}]); Esbuild.install_and_run(:default, ~w(--version))'
    Resolving Hex dependencies...
    Dependency resolution completed:
    New:
      castore 0.1.11
    * Getting castore (Hex package)
    ==> castore
    Compiling 1 file (.ex)
    Generated castore app
    ==> esbuild
    Compiling 3 files (.ex)
    Generated esbuild app

    16:07:22.260 [debug] Downloading esbuild from https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.12.17.tgz
    0.12.17

    $ elixir -e 'Application.put_env(:esbuild, :version, "0.12.17"); Mix.install([{:esbuild, path: "~/src/esbuild"}]); Esbuild.install_and_run(:default, ~w(--version))'
    0.12.17
