### PR TITLE
Fix target detection on FreeBSD

### DIFF
--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -186,6 +186,7 @@ defmodule Esbuild do
         [arch | _] = arch_str |> List.to_string() |> String.split("-")
 
         case arch do
+          "amd64" -> "#{osname}-64"
           "x86_64" -> "#{osname}-64"
           "aarch64" -> "#{osname}-arm64"
           # TODO: remove when we require OTP 24


### PR DESCRIPTION
Hi,

here is a small and quick fix because on FreeBSD, `arch = "amd64"` so the `case` raises and impossible to download esbuild [even if FreeBSD is supported](https://github.com/evanw/esbuild/tree/master/npm/esbuild-freebsd-64).

```elixir
iex(1)> :erlang.system_info(:system_architecture)
'amd64-portbld-freebsd13.0'
```