### PR TITLE
Call :erl_tar.extract/2 with charlist cwd option

### DIFF
--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -158,7 +158,7 @@ defmodule Esbuild do
     url = "https://registry.npmjs.org/#{name}/-/#{name}-#{version}.tgz"
     tar = fetch_body!(url)
 
-    case :erl_tar.extract({:binary, tar}, [:compressed, cwd: tmp_dir]) do
+    case :erl_tar.extract({:binary, tar}, [:compressed, cwd: to_charlist(tmp_dir)]) do
       :ok -> :ok
       other -> raise "couldn't unpack archive: #{inspect(other)}"
     end


### PR DESCRIPTION
This function call is working when cwd is a binary right now,
but it is [documented](https://erlang.org/doc/man/erl_tar.html#extract-2) that cwd should be a charlist (`string()` in erlang type names).

Alternatively I can send a PR to OTP to update the spec to allow a binary there.

This PR is similar to https://github.com/elixir-lang/elixir/pull/9989