### PR TITLE
add --no-runtime-config flag

### DIFF
--- a/lib/mix/tasks/esbuild.ex
+++ b/lib/mix/tasks/esbuild.ex
@@ -11,12 +11,19 @@ defmodule Mix.Tasks.Esbuild do
   Example:
 
   ```bash
-  $ mix esbuild --no-runtime-config default assets/js/app.js --bundle --minify --target=es2016 --outdir=priv/static/assets
+  $ mix esbuild default assets/js/app.js --bundle --minify --target=es2016 --outdir=priv/static/assets
   ```
 
   If esbuild is not installed, it is automatically downloaded.
   Note the arguments given to this task will be appended
   to any configured arguments.
+
+  Flags to control this Mix task must be given before the
+  profile:
+  
+  ```bash
+  $ mix esbuild --no-runtime-config default assets/js/app.js
+  ```
   """
 
   @shortdoc "Invokes esbuild with the profile and args"

--- a/lib/mix/tasks/esbuild.ex
+++ b/lib/mix/tasks/esbuild.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.Esbuild do
 
   Flags to control this Mix task must be given before the
   profile:
-  
+
   ```bash
   $ mix esbuild --no-runtime-config default assets/js/app.js
   ```
@@ -39,6 +39,7 @@ defmodule Mix.Tasks.Esbuild do
       Mix.Task.run("app.config")
     end
 
+    Mix.Task.reenable("esbuild")
     install_and_run(remaining_args)
   end
 
@@ -47,8 +48,6 @@ defmodule Mix.Tasks.Esbuild do
       0 -> :ok
       status -> Mix.raise("`mix esbuild #{Enum.join(all, " ")}` exited with #{status}")
     end
-
-    Mix.Task.reenable("esbuild")
   end
 
   defp install_and_run([]) do

--- a/lib/mix/tasks/esbuild.ex
+++ b/lib/mix/tasks/esbuild.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Esbuild do
   Usage:
 
   ```bash
-  $ mix esbuild TASK_OPTIONS CONTEXT ARGS
+  $ mix esbuild TASK_OPTIONS PROFILE ESBUILD_ARGS
   ```
 
   Example:
@@ -32,10 +32,10 @@ defmodule Mix.Tasks.Esbuild do
 
   @impl true
   def run(args) do
-    options = [switches: [no_runtime_config: :boolean]]
-    {parsed, remaining_args, _errors} = OptionParser.parse_head(args, options)
+    switches = [runtime_config: :boolean]
+    {opts, remaining_args} = OptionParser.parse_head!(args, switches: switches)
 
-    if !parsed[:no_runtime_config] && Code.ensure_loaded?(Mix.Tasks.App.Config) do
+    if Keyword.get(opts, :runtime_config, true) and Code.ensure_loaded?(Mix.Tasks.App.Config) do
       Mix.Task.run("app.config")
     end
 

--- a/lib/mix/tasks/esbuild.ex
+++ b/lib/mix/tasks/esbuild.ex
@@ -5,13 +5,13 @@ defmodule Mix.Tasks.Esbuild do
   Usage:
 
   ```bash
-  $ mix esbuild CONTEXT ARGS
+  $ mix esbuild TASK_OPTIONS CONTEXT ARGS
   ```
 
   Example:
 
   ```bash
-  $ mix esbuild default assets/js/app.js --bundle --minify --target=es2016 --outdir=priv/static/assets
+  $ mix esbuild --no-runtime-config default assets/js/app.js --bundle --minify --target=es2016 --outdir=priv/static/assets
   ```
 
   If esbuild is not installed, it is automatically downloaded.
@@ -24,11 +24,18 @@ defmodule Mix.Tasks.Esbuild do
   use Mix.Task
 
   @impl true
-  def run([profile | args] = all) do
-    if Code.ensure_loaded?(Mix.Tasks.App.Config) do
+  def run(args) do
+    options = [switches: [no_runtime_config: :boolean]]
+    {parsed, remaining_args, _errors} = OptionParser.parse_head(args, options)
+
+    if !parsed[:no_runtime_config] && Code.ensure_loaded?(Mix.Tasks.App.Config) do
       Mix.Task.run("app.config")
     end
 
+    install_and_run(remaining_args)
+  end
+
+  defp install_and_run([profile | args] = all) do
     case Esbuild.install_and_run(String.to_atom(profile), args) do
       0 -> :ok
       status -> Mix.raise("`mix esbuild #{Enum.join(all, " ")}` exited with #{status}")
@@ -37,7 +44,7 @@ defmodule Mix.Tasks.Esbuild do
     Mix.Task.reenable("esbuild")
   end
 
-  def run([]) do
+  defp install_and_run([]) do
     Mix.raise("`mix esbuild` expects the profile as argument")
   end
 end


### PR DESCRIPTION
When building assets as part of a CI pipeline, oftentimes environment
variables that are required by runtime configuration won't be in place
yet. This adds a new `--no-runtime-config` flag to bypass the runtime
configuration check and just use the values given as arguments.

resolves #18 