### PR TITLE
Support armv7l (32 bit raspberry pi)

### DIFF
--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -233,6 +233,7 @@ defmodule Esbuild do
           # TODO: remove when we require OTP 24
           "arm" when osname == :darwin -> "darwin-arm64"
           "arm" -> "#{osname}-arm"
+          "armv7l" -> "#{osname}-arm"
           _ -> raise "could not download esbuild for architecture: #{arch_str}"
         end
     end


### PR DESCRIPTION
Full disclosure, I don't really know what I'm doing. 😄 I was trying to compile my Phoenix app (1.5 with Elixir 1.12.3) on Raspberry Pi 3 and was getting this error:

```
(RuntimeError) could not download esbuild for architecture: armv7l-unknown-linux-gnueabihf
```

This change made things work.