### PR TITLE
Attach system target architecture to saved esbuild executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ And invoke esbuild with:
 $ mix esbuild default assets/js/app.js --bundle --minify --target=es2016 --outdir=priv/static/assets/
 ```
 
-The executable is kept at `_build/esbuild`.
+The executable is kept at `_build/esbuild-TARGET`.
+Where `TARGET` is your system target architecture.
 
 ## Profiles
 
 The first argument to `esbuild` is the execution profile.
 You can define multiple execution profiles with the current
-directory, the OS enviroment, and default arguments to the
+directory, the OS environment, and default arguments to the
 `esbuild` task:
 
 ```elixir

--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -50,7 +50,7 @@ defmodule Esbuild do
   target architecture.
 
   Once you find the location of the executable, you can store it in a
-  `MIX_ESBUILD_PATH` environemnt variable, which you can then read in
+  `MIX_ESBUILD_PATH` environment variable, which you can then read in
   your configuration file:
 
       config :esbuild, path: System.get_env("MIX_ESBUILD_PATH")
@@ -125,11 +125,13 @@ defmodule Esbuild do
   The executable may not be available if it was not yet installed.
   """
   def bin_path do
+    name = "esbuild-#{target()}"
+
     Application.get_env(:esbuild, :path) ||
       if Code.ensure_loaded?(Mix.Project) do
-        Path.join(Path.dirname(Mix.Project.build_path()), "esbuild")
+        Path.join(Path.dirname(Mix.Project.build_path()), name)
       else
-        Path.expand("_build/esbuild")
+        Path.expand("_build/#{name}")
       end
   end
 
@@ -238,7 +240,7 @@ defmodule Esbuild do
           "arm" when osname == :darwin -> "darwin-arm64"
           "arm" -> "#{osname}-arm"
           "armv7l" -> "#{osname}-arm"
-          _ -> raise "could not download esbuild for architecture: #{arch_str}"
+          _ -> raise "esbuild is not available for architecture: #{arch_str}"
         end
     end
   end


### PR DESCRIPTION
This solves unnoticed reusing the executable after switching OS target
in case of coping over the `_build` directory for e.g. caching purposes.

Reference https://github.com/phoenixframework/esbuild/issues/32

---

Proposed CHANGELOG:
- Save executable with attached system target architecture as `_build/esbuild-TARGET`
  By upgrading to this version the executable will be redownloaded.

As this is somehow a breaking behavior, I would release it as a `v0.4` version.
Additionally this would be ideal to pump esbuild to `v0.14.0` (PR will follow).