### PR TITLE
Check esbuild args

### DIFF
--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -161,7 +161,7 @@ defmodule Esbuild do
   """
   def run(profile, extra_args) when is_atom(profile) and is_list(extra_args) do
     config = config_for!(profile)
-    args = config[:args] || []
+    args = config[:args] || raise "no arguments passed to esbuild, check your config and make sure you're using the correct profile"
 
     opts = [
       cd: config[:cd] || File.cwd!(),


### PR DESCRIPTION
When no args are passed to esbuild because the requested profile config
cannot be found, the esbuild executable just hangs and doesn't provide
any feedback or information.