### PR TITLE
Update Esbuild Version to 0.14.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ in dev:
 ```elixir
 def deps do
   [
-    {:esbuild, "~> 0.2", runtime: Mix.env() == :dev}
+    {:esbuild, "~> 0.4", runtime: Mix.env() == :dev}
   ]
 end
 ```
@@ -24,7 +24,7 @@ then it only needs to be a dev dependency:
 ```elixir
 def deps do
   [
-    {:esbuild, "~> 0.2", only: :dev}
+    {:esbuild, "~> 0.4", only: :dev}
   ]
 end
 ```
@@ -33,7 +33,7 @@ Once installed, change your `config/config.exs` to pick your
 esbuild version of choice:
 
 ```elixir
-config :esbuild, version: "0.14.0"
+config :esbuild, version: "0.14.29"
 ```
 
 Now you can install esbuild by running:
@@ -60,7 +60,7 @@ directory, the OS environment, and default arguments to the
 
 ```elixir
 config :esbuild,
-  version: "0.14.0",
+  version: "0.14.29",
   default: [
     args: ~w(js/app.js),
     cd: Path.expand("../assets", __DIR__)
@@ -82,7 +82,7 @@ First add it as a dependency in your `mix.exs`:
 def deps do
   [
     {:phoenix, github: "phoenixframework/phoenix", branch: "v1.5", override: true},
-    {:esbuild, "~> 0.2", runtime: Mix.env() == :dev}
+    {:esbuild, "~> 0.4", runtime: Mix.env() == :dev}
   ]
 end
 ```
@@ -92,7 +92,7 @@ Now let's change `config/config.exs` to configure `esbuild` to use
 
 ```elixir
 config :esbuild,
-  version: "0.14.0",
+  version: "0.14.29",
   default: [
     args: ~w(js/app.js --bundle --target=es2016 --outdir=../priv/static/assets),
     cd: Path.expand("../assets", __DIR__),

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :esbuild,
-  version: "0.14.0",
+  version: "0.14.29",
   another: [
     args: ["--version"]
   ]

--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -1,6 +1,6 @@
 defmodule Esbuild do
   # https://registry.npmjs.org/esbuild/latest
-  @latest_version "0.14.0"
+  @latest_version "0.14.29"
 
   @moduledoc """
   Esbuild is an installer and runner for [esbuild](https://esbuild.github.io).


### PR DESCRIPTION
# Overview

I was taking a look at #38 and noticed the the esbuild version has not been incremented since 0.14.0. I put this pr together quickly in case it would be beneficial to update the latest esbuild version to [0.14.29](https://github.com/evanw/esbuild/releases/tag/v0.14.29).