### PR TITLE
Raise An Error If No Args Are Supplied for Esbuild

### DIFF
--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -161,7 +161,10 @@ defmodule Esbuild do
   """
   def run(profile, extra_args) when is_atom(profile) and is_list(extra_args) do
     config = config_for!(profile)
-    args = config[:args] || []
+
+    args =
+      config[:args] ||
+        raise "no args passed to esbuild, check your esbuild config and make sure you're using the correct profile"
 
     opts = [
       cd: config[:cd] || File.cwd!(),

--- a/test/esbuild_test.exs
+++ b/test/esbuild_test.exs
@@ -4,8 +4,10 @@ defmodule EsbuildTest do
   @version Esbuild.latest_version()
 
   test "run on default" do
+    Application.put_env(:esbuild, :default, args: ["--version"])
+
     assert ExUnit.CaptureIO.capture_io(fn ->
-             assert Esbuild.run(:default, ["--version"]) == 0
+             assert Esbuild.run(:default, []) == 0
            end) =~ @version
   end
 
@@ -21,7 +23,7 @@ defmodule EsbuildTest do
     Mix.Task.rerun("esbuild.install", ["--if-missing"])
 
     assert ExUnit.CaptureIO.capture_io(fn ->
-             assert Esbuild.run(:default, ["--version"]) == 0
+             assert Esbuild.run(:another, []) == 0
            end) =~ "0.12.15"
 
     Application.delete_env(:esbuild, :version)
@@ -29,7 +31,7 @@ defmodule EsbuildTest do
     Mix.Task.rerun("esbuild.install", ["--if-missing"])
 
     assert ExUnit.CaptureIO.capture_io(fn ->
-             assert Esbuild.run(:default, ["--version"]) == 0
+             assert Esbuild.run(:another, []) == 0
            end) =~ @version
   end
 end


### PR DESCRIPTION
# Overview

An exception is manually raised to prevent esbuild from hanging without explanation.

This is a duplicate of https://github.com/phoenixframework/esbuild/pull/47 with test updates to fix tests.