### PR TITLE
Bump Project Version, Esbuild Version For New Release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,6 @@ jobs:
               elixir: '1.10'
               otp: 21
           - pair:
-              elixir: '1.12'
-              otp: 24
-            lint: lint
-          - pair:
               elixir: '1.13'
               otp: 25
             lint: lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,10 @@ jobs:
               elixir: '1.12'
               otp: 24
             lint: lint
+          - pair:
+              elixir: '1.13'
+              otp: 25
+            lint: lint
     steps:
       - uses: actions/checkout@v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v0.5.0 (2022-05-27)
+
+  * Raise exception if no args are found to use with esbuild
+  * Update esbuild to 0.14.41
+  * Support overridable cacertfile
+  * Add support for armv7
+  * Attempt multiple directories to install esbuild
+
 ## v0.4.0 (2021-11-27)
 
   * Attach system target architecture to saved esbuild executable

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ in dev:
 ```elixir
 def deps do
   [
-    {:esbuild, "~> 0.4", runtime: Mix.env() == :dev}
+    {:esbuild, "~> 0.5", runtime: Mix.env() == :dev}
   ]
 end
 ```
@@ -24,7 +24,7 @@ then it only needs to be a dev dependency:
 ```elixir
 def deps do
   [
-    {:esbuild, "~> 0.4", only: :dev}
+    {:esbuild, "~> 0.5", only: :dev}
   ]
 end
 ```
@@ -33,7 +33,7 @@ Once installed, change your `config/config.exs` to pick your
 esbuild version of choice:
 
 ```elixir
-config :esbuild, version: "0.14.29"
+config :esbuild, version: "0.14.41"
 ```
 
 Now you can install esbuild by running:
@@ -60,7 +60,7 @@ directory, the OS environment, and default arguments to the
 
 ```elixir
 config :esbuild,
-  version: "0.14.29",
+  version: "0.14.41",
   default: [
     args: ~w(js/app.js),
     cd: Path.expand("../assets", __DIR__)
@@ -82,7 +82,7 @@ First add it as a dependency in your `mix.exs`:
 def deps do
   [
     {:phoenix, github: "phoenixframework/phoenix", branch: "v1.5", override: true},
-    {:esbuild, "~> 0.4", runtime: Mix.env() == :dev}
+    {:esbuild, "~> 0.5", runtime: Mix.env() == :dev}
   ]
 end
 ```
@@ -92,7 +92,7 @@ Now let's change `config/config.exs` to configure `esbuild` to use
 
 ```elixir
 config :esbuild,
-  version: "0.14.29",
+  version: "0.14.41",
   default: [
     args: ~w(js/app.js --bundle --target=es2016 --outdir=../priv/static/assets),
     cd: Path.expand("../assets", __DIR__),

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :esbuild,
-  version: "0.14.29",
+  version: "0.14.41",
   another: [
     args: ["--version"]
   ]

--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -1,6 +1,6 @@
 defmodule Esbuild do
   # https://registry.npmjs.org/esbuild/latest
-  @latest_version "0.14.29"
+  @latest_version "0.14.41"
 
   @moduledoc """
   Esbuild is an installer and runner for [esbuild](https://esbuild.github.io).

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Esbuild.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.5.0"
   @source_url "https://github.com/phoenixframework/esbuild"
 
   def project do


### PR DESCRIPTION
# Overview

Since there have been several updates to this package since the `0.4.0` I figured I could put together a pr to release a new version with several fixes and enhancements.

Here is the diff from this branch to the `0.4.0` release:

https://github.com/phoenixframework/esbuild/compare/v0.4.0...kinson:bump-versions

If it is too early to cut another release for this project let me know, I can either close it or trim it to just include the `esbuild` update and GitHub CI update!

## Changes

This pr:
* updates the `esbuild` binary version from 0.14.29 -> 0.14.41
* adds elixir 1.13 (OTP 25) to the test matrix for GitHub CI
* bumps the project version to `0.5.0`
* updates the README and CHANGELOGS with version update details