### PR TITLE
Move esbuild to the NPM @esbuild scope

### DIFF
--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -204,11 +204,11 @@ defmodule Esbuild do
         freshdir_p(Path.join(System.tmp_dir!(), "phx-esbuild")) ||
         raise "could not install esbuild. Set MIX_XGD=1 and then set XDG_CACHE_HOME to the path you want to use as cache"
 
-    # TODO: Remove version comparison if esbuild <= 0.15.7 don't need to be supported anymore
     url =
-      if Version.compare(version, "0.15.7") == :gt do
+      if Version.compare(version, "0.16.0") in [:eq, :gt] do
         "https://registry.npmjs.org/@esbuild/-/#{target()}-#{version}.tgz"
       else
+        # TODO: Remove else clause or raise if esbuild < 0.16.0 don't need to be supported anymore
         name = "esbuild-#{target_legacy()}"
         "https://registry.npmjs.org/#{name}/-/#{name}-#{version}.tgz"
       end
@@ -273,8 +273,8 @@ defmodule Esbuild do
     end
   end
 
-  # TODO: Remove if esbuild <= 0.15.7 don't need to be supported anymore
-  # Available targets: https://github.com/evanw/esbuild/tree/v0.15.7/npm
+  # TODO: Remove if esbuild < 0.16.0 don't need to be supported anymore
+  # Available targets: https://github.com/evanw/esbuild/tree/v0.15.18/npm
   defp target_legacy do
     case :os.type() do
       {:win32, _} ->

--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -40,11 +40,11 @@ defmodule Esbuild do
 
   On Unix, the executable will be at:
 
-      NPM_ROOT/esbuild/node_modules/esbuild-TARGET/bin/esbuild
+      NPM_ROOT/esbuild/node_modules/@esbuild/TARGET/bin/esbuild
 
   On Windows, it will be at:
 
-      NPM_ROOT/esbuild/node_modules/esbuild-windows-(32|64)/esbuild.exe
+      NPM_ROOT/esbuild/node_modules/@esbuild/win32-x(32|64)/esbuild.exe
 
   Where `NPM_ROOT` is the result of `npm root -g` and `TARGET` is your system
   target architecture.


### PR DESCRIPTION
This is my take on https://github.com/phoenixframework/esbuild/issues/52.
~~It's not ready until the new breaking version number of esbuild is known for sure.~~

Update: Ready now → esbuild v0.16.0