### PR TITLE
Use proxy authentication during install

### DIFF
--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -301,20 +301,18 @@ defmodule Esbuild do
   end
 
   defp fetch_body!(url) do
+    scheme = URI.parse(url).scheme
     url = String.to_charlist(url)
     Logger.debug("Downloading esbuild from #{url}")
 
     {:ok, _} = Application.ensure_all_started(:inets)
     {:ok, _} = Application.ensure_all_started(:ssl)
 
-    if proxy = System.get_env("HTTP_PROXY") || System.get_env("http_proxy") do
-      Logger.debug("Using HTTP_PROXY: #{proxy}")
-      :httpc.set_options([{:proxy, httpc_proxy(proxy)}])
-    end
-
-    if proxy = System.get_env("HTTPS_PROXY") || System.get_env("https_proxy") do
-      Logger.debug("Using HTTPS_PROXY: #{proxy}")
-      :httpc.set_options([{:https_proxy, httpc_proxy(proxy)}])
+    if proxy = proxy_for_scheme(scheme) do
+      %{host: host, port: port} = URI.parse(proxy)
+      Logger.debug("Using #{String.upcase(scheme)}_PROXY: #{proxy}")
+      set_option = if "https" == scheme, do: :https_proxy, else: :proxy
+      :httpc.set_options([{set_option, {{String.to_charlist(host), port}, []}}])
     end
 
     # https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/inets
@@ -329,7 +327,7 @@ defmodule Esbuild do
           match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
         ]
       ]
-    ]
+    ] |> maybe_add_proxy_auth(scheme)
 
     options = [body_format: :binary]
 
@@ -347,10 +345,29 @@ defmodule Esbuild do
     end
   end
 
-  defp httpc_proxy(proxy) do
-    %{host: host, userinfo: userinfo, port: port} = URI.parse(proxy)
-    authority = if userinfo, do: "#{userinfo}@#{host}", else: host
-    {{String.to_charlist(authority), port}, []}
+  defp proxy_for_scheme("http") do
+    System.get_env("HTTP_PROXY") || System.get_env("http_proxy")
+  end
+
+  defp proxy_for_scheme("https") do
+    System.get_env("HTTPS_PROXY") || System.get_env("https_proxy")
+  end
+
+  defp maybe_add_proxy_auth(http_options, scheme) do
+    case proxy_auth(scheme) do
+      nil -> http_options
+      auth -> [{:proxy_auth, auth} | http_options]
+    end
+  end
+
+  defp proxy_auth(scheme) do
+    with proxy when is_binary(proxy) <- proxy_for_scheme(scheme),
+         %{userinfo: userinfo} when is_binary(userinfo) <- URI.parse(proxy),
+         [username, password] <- String.split(userinfo, ":") do
+      {String.to_charlist(username), String.to_charlist(password)}
+    else
+      _ -> nil
+    end
   end
 
   defp cacertfile() do


### PR DESCRIPTION
Fetching the esbuild executable during install through a http proxy that requires authentication didn't work. 

This PR extends the installation by picking up and applying HTTP Basic Authentication credentials from the proxy environment variables HTTPS_PROXY, https_proxy, HTTP_PROXY or http_proxy, depending on the scheme of the fetch URL.

eg. `export https_proxy=http://username:password@yourproxy.example.com`

See #54 for further motivation.