### PR TITLE
refactor: don't fail if extra signatures we don't care about

### DIFF
--- a/lib/esbuild/npm_registry.ex
+++ b/lib/esbuild/npm_registry.ex
@@ -19,17 +19,17 @@ defmodule Esbuild.NpmRegistry do
       "_id" => id,
       "dist" => %{
         "integrity" => integrity,
-        "signatures" => [
-          %{
-            "keyid" => @public_key_id,
-            "sig" => signature
-          }
-        ],
+        "signatures" => signatures,
         "tarball" => tarball
       }
     } =
       fetch_file!("#{@base_url}/#{name}/#{version}")
       |> Jason.decode!()
+
+    %{"sig" => signature} =
+      signatures
+      |> Enum.find(fn %{"keyid" => keyid} -> keyid == @public_key_id end) ||
+        raise "missing signature"
 
     verify_signature!("#{id}:#{integrity}", signature)
     tar = fetch_file!(tarball)


### PR DESCRIPTION
Not seen cases of this but per their spec is possible multiple signatures coming in this field.
https://docs.npmjs.com/about-registry-signatures#supporting-signatures-on-third-party-registries
Just playing safe so that it doesn't break if something changes in the package metadata response.