### PR TITLE
Add support for riscv64 arch

### DIFF
--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -286,6 +286,7 @@ defmodule Esbuild do
           "i686" -> "#{osname}-ia32"
           "i386" -> "#{osname}-ia32"
           "aarch64" -> "#{osname}-arm64"
+          "riscv64" -> "#{osname}-riscv64"
           # TODO: remove when we require OTP 24
           "arm" when osname == :darwin -> "darwin-arm64"
           "arm" -> "#{osname}-arm"


### PR DESCRIPTION
Scaleway is now offering easy access to RISC-V servers, so naturally, I wanted to see if I could get Phoenix running on it.

This patch allows the `esbuild` portion of the Phoenix installer to work on the `riscv64` architecture.