### PR TITLE
Feature: Don't check version if path is present

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :esbuild,
-  version: "0.17.11",
+  version: "0.23.0",
   another: [
     args: ["--version"]
   ]

--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -65,7 +65,7 @@ defmodule Esbuild do
 
   @doc false
   def start(_, _) do
-    unless Application.get_env(:esbuild, :version) or Application.get_env(:esbuild, :path) do
+    unless Application.get_env(:esbuild, :version) || Application.get_env(:esbuild, :path) do
       Logger.warning("""
       esbuild version is not configured. Please set it in your config files:
 

--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -21,9 +21,13 @@ defmodule Esbuild do
 
   ## Esbuild configuration
 
-  There are two global configurations for the esbuild application:
+  There are four global configurations for the esbuild application:
 
     * `:version` - the expected esbuild version
+
+    * `:version_check` - whether to perform the version check or not.
+      Useful when you manage the esbuild executable with an external
+      tool (eg. npm)
 
     * `:cacerts_path` - the directory to find certificates for
       https connections

--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -1,6 +1,6 @@
 defmodule Esbuild do
   # https://registry.npmjs.org/esbuild/latest
-  @latest_version "0.17.11"
+  @latest_version "0.23.00"
 
   @moduledoc """
   Esbuild is an installer and runner for [esbuild](https://esbuild.github.io).
@@ -65,7 +65,7 @@ defmodule Esbuild do
 
   @doc false
   def start(_, _) do
-    unless Application.get_env(:esbuild, :version) do
+    unless Application.get_env(:esbuild, :version) or Application.get_env(:esbuild, :path) do
       Logger.warning("""
       esbuild version is not configured. Please set it in your config files:
 
@@ -100,7 +100,10 @@ defmodule Esbuild do
   Returns the configured esbuild version.
   """
   def configured_version do
-    Application.get_env(:esbuild, :version, latest_version())
+    default_version =
+      if Application.get_env(:esbuild, :path), do: bin_version(), else: latest_version()
+
+    Application.get_env(:esbuild, :version, default_version)
   end
 
   @doc """

--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -23,7 +23,8 @@ defmodule Esbuild do
 
   There are four global configurations for the esbuild application:
 
-    * `:version` - the expected esbuild version
+    * `:version` - the expected esbuild version. You can omit this if
+      `:version_check` is set to `false`
 
     * `:version_check` - whether to perform the version check or not.
       Useful when you manage the esbuild executable with an external

--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -65,17 +65,15 @@ defmodule Esbuild do
 
   @doc false
   def start(_, _) do
-    skip_version_check = not Application.get_env(:esbuild, :version_check, true)
+    if Application.get_env(:esbuild, :version_check, true) do
+      unless Application.get_env(:esbuild, :version) do
+        Logger.warning("""
+        esbuild version is not configured. Please set it in your config files:
 
-    unless skip_version_check || Application.get_env(:esbuild, :version) do
-      Logger.warning("""
-      esbuild version is not configured. Please set it in your config files:
+            config :esbuild, :version, "#{latest_version()}"
+        """)
+      end
 
-          config :esbuild, :version, "#{latest_version()}"
-      """)
-    end
-
-    unless skip_version_check do
       configured_version = configured_version()
 
       case bin_version() do

--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -23,8 +23,7 @@ defmodule Esbuild do
 
   There are four global configurations for the esbuild application:
 
-    * `:version` - the expected esbuild version. You can omit this if
-      `:version_check` is set to `false`
+    * `:version` - the expected esbuild version
 
     * `:version_check` - whether to perform the version check or not.
       Useful when you manage the esbuild executable with an external

--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -100,8 +100,8 @@ defmodule Esbuild do
   Returns the configured esbuild version.
   """
   def configured_version do
-    default_version =
-      if Application.get_env(:esbuild, :path), do: bin_version(), else: latest_version()
+    {:ok, default_version} =
+      if Application.get_env(:esbuild, :path), do: bin_version(), else: {:ok, latest_version()}
 
     Application.get_env(:esbuild, :version, default_version)
   end

--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -100,8 +100,12 @@ defmodule Esbuild do
   Returns the configured esbuild version.
   """
   def configured_version do
-    {:ok, default_version} =
-      if Application.get_env(:esbuild, :path), do: bin_version(), else: {:ok, latest_version()}
+    default_version =
+      with false <- :esbuild |> Application.get_env(:path) |> is_nil, {:ok, version} <- bin_version() do
+        version
+      else
+        _ -> latest_version()
+      end
 
     Application.get_env(:esbuild, :version, default_version)
   end


### PR DESCRIPTION
I think checking the existence of the `version` param is redundant when using a path for `esbuild` binary. In this case, `esbuild` is probably managed with an external package manager (eg. `npm`). 