### PR TITLE
Use `JSON` if it exists

### DIFF
--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -188,6 +188,19 @@ defmodule Esbuild do
     |> elem(1)
   end
 
+  def json_library() do
+    case Application.get_env(:esbuild, :json_library) do
+      nil ->
+        case Code.ensure_loaded(JSON) do
+          {:module, _} -> JSON
+          {:error, _} -> Jason
+        end
+
+      lib ->
+        lib
+    end
+  end
+
   defp start_unique_install_worker() do
     ref =
       __MODULE__.Supervisor

--- a/lib/esbuild/npm_registry.ex
+++ b/lib/esbuild/npm_registry.ex
@@ -37,7 +37,7 @@ defmodule Esbuild.NpmRegistry do
       }
     } =
       fetch_file!(url)
-      |> Jason.decode!()
+      |> Esbuild.json_library().decode!()
 
     %{"sig" => signature} =
       signatures


### PR DESCRIPTION
I'm unsure if this is the best approach, so consider this more of a draft than a complete solution.

The intent is to use the `JSON` module from Elixir 1.18.x instead of `Jason`, but I've kept the `Jason` dep as the fallback.

I do think it would be better to have `Jason` as an optional dep and have the project which is using `Esbuild` include `Jason` instead, but this would also require changes when creating new Phoenix projects to make sure `Jason` is added in the deps.