### PR TITLE
respect erlang's system cacerts

### DIFF
--- a/lib/esbuild.ex
+++ b/lib/esbuild.ex
@@ -29,9 +29,6 @@ defmodule Esbuild do
       Useful when you manage the esbuild executable with an external
       tool (eg. npm)
 
-    * `:cacerts_path` - the directory to find certificates for
-      https connections
-
     * `:path` - the path to find the esbuild executable at. By
       default, it is automatically downloaded and placed inside
       the `_build` directory of your current app

--- a/lib/esbuild/npm_registry.ex
+++ b/lib/esbuild/npm_registry.ex
@@ -91,7 +91,7 @@ defmodule Esbuild.NpmRegistry do
         ssl: [
           verify: :verify_peer,
           # https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/inets
-          cacertfile: cacertfile() |> String.to_charlist(),
+          cacerts: :public_key.cacerts_get(),
           depth: 2,
           customize_hostname_check: [
             match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
@@ -126,10 +126,6 @@ defmodule Esbuild.NpmRegistry do
     else
       _ -> nil
     end
-  end
-
-  defp cacertfile() do
-    Application.get_env(:esbuild, :cacerts_path) || CAStore.file_path()
   end
 
   defp verify_signature!(message, signature) do


### PR DESCRIPTION
Instead of using `CaStore` - we shoudl follow the rest of the Phoenix application and use the embedded certificate store of the system. The user can still override if needed, but we're not bound to a third party library.